### PR TITLE
refactor: Move today and yesterday getters to a factory

### DIFF
--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -1,0 +1,4 @@
+import ProperDate from "./model";
+
+export const getToday = () => new ProperDate();
+export const getYesterday = () => getToday().addDays(-1);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,4 @@
 import ProperDate from "./model";
 export default ProperDate;
+
+export * from "./factory";

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -26,18 +26,6 @@ export default class ProperDate implements ProperDateInterface {
     }
   }
 
-  // TODO: move to a factory
-  static get Today(): ProperDate {
-    return new ProperDate();
-  }
-
-  // TODO: move to a factory
-  static get Yesterday(): ProperDate {
-    const now = new Date();
-    now.setDate(now.getDate() - 1);
-    return new ProperDate(now);
-  }
-
   static compare(a: ProperDate, b: ProperDate) {
     return a.getTime() - b.getTime();
   }

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import ProperDate from "../lib/model";
+import { getToday, getYesterday } from "../lib/factory";
+
+describe("factory", () => {
+  describe("today", () => {
+    test("returns a ProperDate instance for today's date", () => {
+      // TODO: freeze time, making these more deterministic
+      const subject = getToday();
+      const now = new Date();
+      const otherDate = new Date("1963-03-15");
+
+      expect(subject.equals(new ProperDate(now))).toStrictEqual(true);
+      expect(subject.equals(new ProperDate(otherDate))).toStrictEqual(false);
+    });
+  });
+
+  describe("yesterday", () => {
+    test("returns a ProperDate instance for yesterday's date", () => {
+      // TODO: freeze time, making these more deterministic
+      const subject = getYesterday();
+      const now = new Date();
+      const yesterdayDate = new Date(now);
+      yesterdayDate.setDate(now.getDate() - 1);
+
+      expect(subject.equals(new ProperDate(yesterdayDate))).toStrictEqual(true);
+      expect(subject.equals(new ProperDate(now))).toStrictEqual(false);
+    });
+  });
+});

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,30 +1,27 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, afterEach, vi, describe, expect, test } from "vitest";
 import ProperDate from "../lib/model";
 import { getToday, getYesterday } from "../lib/factory";
 
 describe("factory", () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date("2025-01-02T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("today", () => {
     test("returns a ProperDate instance for today's date", () => {
-      // TODO: freeze time, making these more deterministic
       const subject = getToday();
-      const now = new Date();
-      const otherDate = new Date("1963-03-15");
-
-      expect(subject.equals(new ProperDate(now))).toStrictEqual(true);
-      expect(subject.equals(new ProperDate(otherDate))).toStrictEqual(false);
+      expect(subject.equals(new ProperDate("2025-01-02"))).toStrictEqual(true);
     });
   });
 
   describe("yesterday", () => {
     test("returns a ProperDate instance for yesterday's date", () => {
-      // TODO: freeze time, making these more deterministic
       const subject = getYesterday();
-      const now = new Date();
-      const yesterdayDate = new Date(now);
-      yesterdayDate.setDate(now.getDate() - 1);
-
-      expect(subject.equals(new ProperDate(yesterdayDate))).toStrictEqual(true);
-      expect(subject.equals(new ProperDate(now))).toStrictEqual(false);
+      expect(subject.equals(new ProperDate("2025-01-01"))).toStrictEqual(true);
     });
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,7 +3,6 @@ import ProperDate, { getToday, getYesterday } from "../lib";
 
 describe("ProperDate", () => {
   beforeEach(() => {
-    // TODO: this doesn't seem to work
     vi.setSystemTime(new Date("2025-01-02T00:00:00Z"));
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+import ProperDate, { getToday, getYesterday } from "../lib";
+
+describe("ProperDate", () => {
+  beforeEach(() => {
+    // TODO: this doesn't seem to work
+    vi.setSystemTime(new Date("2025-01-02T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("exports as expected", () => {
+    const sampleProperDate = new ProperDate("1776-07-04");
+    expect(sampleProperDate.toString()).toBe("1776-07-04");
+
+    const today = getToday();
+    expect(today instanceof ProperDate).toBe(true);
+    expect(today.toString()).toBe("2025-01-02");
+
+    const yesterday = getYesterday();
+    expect(yesterday instanceof ProperDate).toBe(true);
+    expect(yesterday.toString()).toBe("2025-01-01");
+  });
+});

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -112,29 +112,6 @@ describe("ProperDate", () => {
     });
   });
 
-  describe(".Today", () => {
-    test("returns an instance for today's date", () => {
-      const subject = ProperDate.Today;
-      const now = new Date();
-      const otherDate = new Date("1963-03-15");
-
-      expect(subject.equals(new ProperDate(now))).toStrictEqual(true);
-      expect(subject.equals(new ProperDate(otherDate))).toStrictEqual(false);
-    });
-  });
-
-  describe(".Yesterday", () => {
-    test("returns an instance for yesterday's date", () => {
-      const subject = ProperDate.Yesterday;
-      const now = new Date();
-      const yesterday = new Date(now);
-      yesterday.setDate(now.getDate() - 1);
-
-      expect(subject.equals(new ProperDate(yesterday))).toStrictEqual(true);
-      expect(subject.equals(new ProperDate(now))).toStrictEqual(false);
-    });
-  });
-
   describe("#equals", () => {
     test("returns true if the dates are equal", () => {
       const subject = new ProperDate("2023-12-25");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new utilities for generating today’s and yesterday’s date, offering a streamlined interface for date retrieval.
  
- **Bug Fixes**
  - Removed outdated test suites for legacy date accessors, ensuring tests reflect current functionality.

- **Refactor**
  - Transitioned from legacy date accessors to a unified approach, ensuring consistency in date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->