### PR TITLE
chore(ci): Publish upon release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  release:
+    types: [created, published]
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Tag push doesn't seem to cover ReleasePlease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the automated publishing process so that new releases now trigger our workflow upon creation and publication, ensuring timely deployment of updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->